### PR TITLE
add retry system for tests

### DIFF
--- a/offchain/danaswap-api/test/TestUtil.purs
+++ b/offchain/danaswap-api/test/TestUtil.purs
@@ -95,6 +95,7 @@ okayErrs =
   , "Process ctl-server exited. Output:"
   , "timed out waiting for tx"
   ]
+
 -- | returns a contiunation that gets the EnvRunner
 -- This is nesecary to allow control over which parts
 -- run once vs each time

--- a/offchain/danaswap-api/test/TestUtil.purs
+++ b/offchain/danaswap-api/test/TestUtil.purs
@@ -57,8 +57,8 @@ runWithMode mode spec = do
 -- the function `it` transforms this type into an EnvSpec
 useRunnerSimple :: forall a. Contract () a -> EnvRunner -> Aff Unit
 useRunnerSimple contract runner = do
-  runner \env alice ->
-    retryOkayErrs $ runContractInEnv env
+  retryOkayErrs $ runner \env alice ->
+    runContractInEnv env
       $ withKeyWallet alice
       $ void contract
 

--- a/offchain/danaswap-api/test/TestUtil.purs
+++ b/offchain/danaswap-api/test/TestUtil.purs
@@ -19,9 +19,11 @@ import Data.BigInt as BigInt
 import Data.Identity (Identity)
 import Data.Log.Formatter.Pretty (prettyFormatter)
 import Data.Log.Message (Message)
+import Data.String (trim)
 import Data.UInt as UInt
 import Data.Unfoldable (replicateA)
-import Effect.Exception (throw)
+import Effect.Aff.Retry (limitRetries, recovering)
+import Effect.Exception (message, throw)
 import Effect.Random (randomInt)
 import Node.Encoding (Encoding(..))
 import Node.FS.Aff (appendTextFile)
@@ -56,10 +58,43 @@ runWithMode mode spec = do
 useRunnerSimple :: forall a. Contract () a -> EnvRunner -> Aff Unit
 useRunnerSimple contract runner = do
   runner \env alice ->
-    runContractInEnv env
+    retryOkayErrs $ runContractInEnv env
       $ withKeyWallet alice
       $ void contract
 
+retryOkayErrs :: Aff Unit -> Aff Unit
+retryOkayErrs aff =
+  recovering
+    (limitRetries 5)
+    [ \_ err' -> do
+        let err = trim $ message err'
+        if err `elem` badErrors then pure false
+        else do
+          if err `elem` (trim <$> okayErrs) then pure true
+          else do
+            log $ "failed with an error not makred as retryable"
+            log $ "if this error is okay add it to the okayErrs list in ./test/TestUtil.purs"
+            log $ "exact error was:" <> show err
+            log $ "\nfull error:\n" <> show err' <> "\n"
+            pure $ false
+    ]
+    \_ -> aff
+
+-- Errors where we don't
+-- want to suggest adding
+-- them to okayErrs
+badErrors :: Array String
+badErrors =
+  [ "Expected Error"
+  ]
+
+okayErrs :: Array String
+okayErrs =
+  [ "(ClientHttpError There was a problem making the request: request failed)"
+  , "Process ogmios-datum-cache exited. Output:"
+  , "Process ctl-server exited. Output:"
+  , "timed out waiting for tx"
+  ]
 -- | returns a contiunation that gets the EnvRunner
 -- This is nesecary to allow control over which parts
 -- run once vs each time


### PR DESCRIPTION
Some of the plutip tests are pretty flaky with (AFAIK) plutip specific errors
so this adds some retries for a specific whitelist of errors.

- [x] Every newly introduced function needs to have a [documentation](https://github.com/purescript/documentation/blob/master/language/Syntax.md#comments)
- [ ] The impure tests via `nix run .#offchain:test` were run and all are passing.
- [x] Where applicable, grammar, punctuation, and spelling within code and comments should be plausibly correct.
- [x] The issue(s) that the work is addressing should be linked in the PR description.
- [x] Any significant changes beyond what's clear from the linked issue(s) are documented in the PR description

